### PR TITLE
Use environment variables for database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # perpustakaan-digital
+
+## Environment Variables
+
+The application reads database credentials from the environment. Set the
+following variables before running any PHP scripts:
+
+- `DB_HOST` – database host
+- `DB_USER` – database username
+- `DB_PASS` – database password
+- `DB_NAME` – database name
+
+For local development you can copy `local_env.sh.example` to `local_env.sh`,
+fill in the correct values, and source it:
+
+```sh
+cp local_env.sh.example local_env.sh
+# edit local_env.sh with your credentials
+source local_env.sh
+```
+
+The scripts will then pick up the credentials via `getenv()` calls.

--- a/koneksi.php
+++ b/koneksi.php
@@ -1,10 +1,10 @@
 <?php
 mysqli_report(MYSQLI_REPORT_OFF);
 
-$DB_HOST = "sql106.infinityfree.com";
-$DB_USER = "if0_39628444";
-$DB_PASS = "yQkJsf8Vqf6FOl";
-$DB_NAME = "if0_39628444_andhika";
+$DB_HOST = getenv('DB_HOST');
+$DB_USER = getenv('DB_USER');
+$DB_PASS = getenv('DB_PASS');
+$DB_NAME = getenv('DB_NAME');
 
 $koneksi = @new mysqli($DB_HOST, $DB_USER, $DB_PASS, $DB_NAME);
 if ($koneksi && !$koneksi->connect_errno) {

--- a/local_env.sh.example
+++ b/local_env.sh.example
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Copy this file to local_env.sh and adjust values for your environment
+export DB_HOST=your_db_host
+export DB_USER=your_db_user
+export DB_PASS=your_db_pass
+export DB_NAME=your_db_name

--- a/login.php
+++ b/login.php
@@ -10,10 +10,10 @@ session_set_cookie_params([
 session_start();
 
 // 1) Koneksi
-$DB_HOST = "sql106.infinityfree.com";
-$DB_USER = "if0_39628444";
-$DB_PASS = "yQkJsf8Vqf6FOl";
-$DB_NAME = "if0_39628444_andhika";
+$DB_HOST = getenv('DB_HOST');
+$DB_USER = getenv('DB_USER');
+$DB_PASS = getenv('DB_PASS');
+$DB_NAME = getenv('DB_NAME');
 $koneksi = @mysqli_connect($DB_HOST, $DB_USER, $DB_PASS, $DB_NAME);
 if (!$koneksi) { error_log("DB connect error: ".mysqli_connect_error()); header('Location: login.html?error=server'); exit; }
 mysqli_set_charset($koneksi, 'utf8mb4');

--- a/migrate_passwords.php
+++ b/migrate_passwords.php
@@ -1,9 +1,9 @@
 <?php
 // migrate_passwords.php
-$DB_HOST = "sql106.infinityfree.com";
-$DB_USER = "if0_39628444";
-$DB_PASS = "yQkJsf8Vqf6FOl";
-$DB_NAME = "if0_39628444_andhika";
+$DB_HOST = getenv('DB_HOST');
+$DB_USER = getenv('DB_USER');
+$DB_PASS = getenv('DB_PASS');
+$DB_NAME = getenv('DB_NAME');
 
 $k = mysqli_connect($DB_HOST, $DB_USER, $DB_PASS, $DB_NAME);
 if (!$k) { die("DB error: ".mysqli_connect_error()); }


### PR DESCRIPTION
## Summary
- replace hard-coded DB credentials in PHP scripts with getenv()
- document required DB_* environment variables in README
- add local_env.sh.example to help set variables during local development

## Testing
- `php -l koneksi.php login.php migrate_passwords.php`
- `sh -n local_env.sh.example`

------
https://chatgpt.com/codex/tasks/task_e_68b67e40ec84833187f5995fc28d7988