### PR TITLE
Remove redundant session_start in index

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,8 +3,6 @@ include 'time_check.php';
 date_default_timezone_set("Asia/Jakarta");
 $hour = date('H');
 
-session_start();
-
 $current_file = basename($_SERVER['PHP_SELF']); // ambil nama file sekarang
 
 // Kalau bukan login/logout & belum ada allow_after_hours & jam di luar range → redirect

--- a/time_check.php
+++ b/time_check.php
@@ -1,6 +1,8 @@
 <?php
 date_default_timezone_set("Asia/Jakarta");
-session_start();
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
 $hour = date('H');
 $current_file = basename($_SERVER['PHP_SELF']);


### PR DESCRIPTION
## Summary
- Remove unnecessary session_start in index.php to rely on time_check.php's session handling

## Testing
- `php -l index.php`
- `php -l time_check.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6815a4bc88331b2f275aaa35b530c